### PR TITLE
Update fmtcount-manual.tex Incorrect section number

### DIFF
--- a/trunk/fmtcount-manual.tex
+++ b/trunk/fmtcount-manual.tex
@@ -137,7 +137,7 @@ This is like \cs{ordinal} but takes an actual number rather than a counter as th
 \cs{numberstring}\marg{counter}\oarg{gender}
 \end{definition}
 This will print the value of \meta{counter} as text.  E.g.\
-\verb"\numberstring{section}" will produce: three. The optional
+\verb"\numberstring{section}" will produce: \numberstring{section}. The optional
 argument is the same as that for \cs{ordinal}.
 
 \begin{definition}[\DescribeMacro{\Numberstring}]


### PR DESCRIPTION
We are on section 2, so `\numberstring{section} ` must probably display "two" in the doc. But instead of hardcoding "two", using `\numberstring{section}` is probably better, if in future this section has another number.