### PR TITLE
Update fmtcount-manual.tex incorrect example fixed

### DIFF
--- a/trunk/fmtcount-manual.tex
+++ b/trunk/fmtcount-manual.tex
@@ -152,7 +152,7 @@ uppercase.  For example, \verb"\Numberstring{section}" will produce:
 \end{definition}
 This does the same as \cs{numberstring}, but converts the string to
 upper case. Note that
-\verb"\MakeUppercase{\NUMBERstring{"\meta{counter}\verb'}}' doesn't
+\verb"\MakeUppercase{\Numberstring{"\meta{counter}\verb'}}' doesn't
 work, due to the way that \cs{MakeUppercase} expands its
 argument\footnote{See all the various postings to
 \texttt{comp.text.tex} about \cs{MakeUppercase}}.


### PR DESCRIPTION
Writing *Note that `\MakeUppercase{\NUMBERstring{section}}` doesn't work* is probably not what was intended because `\NUMBERstring{section}` gives already an UPPERCASE word, so adding `\MakeUppercase` has no effect. But, with `\MakeUppercase{\Numberstring{section}}` we can hope that we obtain "TWO", but effectively, because the way that `\MakeUppercase`works, we don't obtain "TWO" but "Two". so the remark is necessary for `\MakeUppercase{\Numberstring{section}}`, not for `\MakeUppercase{\NUMBERstring{section}}`.