### PR TITLE
Update fmtcount-manual.tex Correct dead link (but... read below)

### DIFF
--- a/trunk/fmtcount-manual.tex
+++ b/trunk/fmtcount-manual.tex
@@ -576,7 +576,7 @@ L'effet de l'option \texttt{dialect} est illustré ainsi:\newline
   \pkgopt{belgian} & septante pour 70, quatre-vingts pour 80, et
   nonante pour 90, \\
   \pkgopt{swiss} &septante pour 70, huitante\footnote{voir
-    \href{http://www.alain.be/Boece/huitante_octante.html}{Octante et
+    \href{https://web.archive.org/web/20171216043052/http://www.alain.be/Boece/huitante_octante.html}{Octante et
       huitante} sur le site d'Alain Lassine} pour 80, et
   nonante pour 90
 \end{tabularx}


### PR DESCRIPTION
I replace the link to a link to the Internet Archive. Checking the name of the site owner, I see some obituaries (dated August 2015), but perhaps it's another person with same name. Perhaps it's better to replace by another website with similar content?